### PR TITLE
Modify URL_MATCH so it catches some urls it was missing

### DIFF
--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -2,8 +2,6 @@
 # The methods added to this helper will be available to all templates in the application.
 
 module ApplicationHelper
-  URL_MATCH = /(https?):\/\/(([-\w\.]+)+(:\d+)?(([\w%\/_\.\-:\+]*(\?\S+)?)?)?)/i
-
   include Misc
 
   def current_pages
@@ -90,8 +88,8 @@ module ApplicationHelper
     txt.gsub!(/#([0-9]+)/, "<a href=\"/tasks/view/\\1\">#\\1</a>")
     txt.gsub!(/([\w\.\-\+]+)@((?:[-a-z0-9]+\.)+[a-z]{2,})/i, '<a href="mailto:\\0">\\0</a>')
     txt.gsub!(/(http\S+(?:gif|jpg|png))(\?.*)?/i, "<a href=\"\\0\" target=\"blank\">\\0</a>")
-    txt.gsub!(URL_MATCH) {|m|
-      elems = m.match(URL_MATCH).to_a
+    txt.gsub!(URI.regexp) { |m|
+      elems = m.match(URI.regexp).to_a
       "<a href=\"#{elems[0]}\" target=\"_blank\">".html_safe + elems[0] + "</a>".html_safe
     }
 


### PR DESCRIPTION
If a task comment contained URLs, this issue was causing some parts of
those URLs to not be included in the links.

Examples of urls that were getting missed:
1. http://foo.com?bar=baz
   Everything after (and including) the ? was not included in the url.
2. http://foo.com/bar-baz
   Everything after (and including) the hyphen was not included in the url.
