### PR TITLE
Supress "Global access to Rake DSL methods is deprecated" warnings

### DIFF
--- a/test/blueprints.rb
+++ b/test/blueprints.rb
@@ -2,6 +2,8 @@ require "machinist/active_record"
 require "sham"
 require 'faker'
 
+include Rake::DSL
+
 module Faker
   class Lorem
      def self.sentences(sentence_count = 3)


### PR DESCRIPTION
When running

```
rake db:seed
```

screen is filled with messages:

```
WARNING: DSL method Machinist::Lathe#task called at /home/den/jobsworth/test/blueprints.rb:127:in `block in <top (required)>'
WARNING: Global access to Rake DSL methods is deprecated.  Please include
    ...  Rake::DSL into classes and modules which use the Rake DSL methods.
```
