### PR TITLE
Logo invisible if not set

### DIFF
--- a/app/views/layouts/_menu.html.erb
+++ b/app/views/layouts/_menu.html.erb
@@ -1,10 +1,8 @@
-<div id="menu_logo">
-  <% if current_user.company.logo? %>
+<% if current_user.company.logo? %>
+  <div id="menu_logo">
     <%= image_tag("/companies/show_logo/#{current_user.company.id}", :alt => "logo" ) %>
-  <% else %>
-    <%= image_tag("logo.gif", :alt => "logo" ) %>
-  <% end %>
-</div>
+  </div>
+<% end %>
 
 <div id="topper-worktime-area">
   <% if total_today > 0 %>


### PR DESCRIPTION
This just removes the logo up the top completely, which enables jobsworth to start from the top of the screen.

I'm thinking about adding a checkbox to delete the logo (in company setting) also. 

For now though, this just makes it a little tidier and gives a tiny bit more real estate.
