### PR TITLE
Error updating users with 2-letter username

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -58,7 +58,7 @@ class User < ActiveRecord::Base
 
   validates :username,
             :presence => true,
-            :length => {:minimum => 3, :maximum => 200},
+            :length => {:minimum => 2, :maximum => 200},
             :uniqueness => { :case_sensitive => false, :scope => "company_id" }
 
   validates :password, :confirmation => true, :if => :password_required?


### PR DESCRIPTION
I run into another issue concerned db migration from ClockingIT: users with 2-letter logins couldn't reset their passwords because of username length limitation of 3 chars.
The simple patch reduces this restriction.
