### PR TITLE
Ignore bundler's binstubs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 *~
 *#
 \.#*
+bin/
 *.bak
 \.svn
 /index


### PR DESCRIPTION
If you use bundler with `--binstubs` option, there will be many executables in the bin directory.
