### PR TITLE
This fixes Task#18810: Widget Tasks, Settings, Everyone, Recent, All Tasks, shows the oldest tasks

### DIFF
--- a/app/controllers/widgets_controller.rb
+++ b/app/controllers/widgets_controller.rb
@@ -163,9 +163,9 @@ class WidgetsController < ApplicationController
 
       @items = case @widget.order_by
                when 'priority' then
-                   current_user.company.sort(@items)[0, @widget.number]
+                 current_user.company.sort(@items)[0, @widget.number]
                when 'date' then
-                   @items.sort_by {|t| t.created_at.to_i }[0, @widget.number]
+                 @items.sort_by {|t| t.created_at.to_i }.last(@widget.number)
                end
   end
 


### PR DESCRIPTION
Sotry: http://squish.ish.com.au/tasks/18810
The oldest tasks were being shown because of the ascending order of elements in the sorted array in Widgets Controller
