### PR TITLE
This fixes "Template attributes are not loaded when task is created"

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -406,6 +406,8 @@ class TasksController < ApplicationController
   def clone
     @template = current_templates.find_by_task_num(params[:id])
     @task = TaskRecord.new(@template.as_json['template'])
+    @from_template = 1
+    @task.tags = @template.tags
     @task.todos = @template.todos
     @task.customers = @template.customers
     @task.users = @template.users

--- a/app/views/tasks/_attributes.html.erb
+++ b/app/views/tasks/_attributes.html.erb
@@ -9,7 +9,7 @@
 
 
   <% current_user.company.properties.each do |p|
-       selected = @task.new_record? ? p.default_value : @task.property_value(p)
+       selected = (@task.new_record? && @from_template.nil?) ? p.default_value : @task.property_value(p)
        name = "property_#{ p.id }" -%>
       <label for="<%= name %>"><%= h(p.name) %></label>
       <select name="task[properties][<%= p.id %>]" id="<%= name %>">


### PR DESCRIPTION
https://github.com/ari/jobsworth/issues/481
Template tags were not copied to the new task and also the default option
was being selected because task from template was being treated as a new task.
It should have been treated as a task from existing templates instead which have these options set.
