### PR TITLE
Add  feature that allows users comment to be made private by default

### DIFF
--- a/app/models/mailman.rb
+++ b/app/models/mailman.rb
@@ -195,6 +195,10 @@ class Mailman < ActionMailer::Base
       :body => wrapper.body
     )
 
+    if wrapper.user.comment_private_by_default?
+      work_log.update_column(:access_level_id,2)
+    end
+
     work_log.create_event_log(
       :user => wrapper.user,
       :event_type => EventLog::TASK_COMMENT,

--- a/app/views/tasks/_new_comment.html.erb
+++ b/app/views/tasks/_new_comment.html.erb
@@ -38,10 +38,17 @@
   </div>
 
   <% if current_user.access_level_id > 1 %>
+
     <div id="accessLevel_container">
+
       <%= fields_for :work_log do |f| %>
-        <div id="user_access_public_privat"></div>
-        <%= f.select :access_level_id, ['1', '2']%>
+        <% if !current_user.comment_private_by_default? %>
+          <div id="user_access_public_privat"> </div>
+          <%= f.select :access_level_id, ['1', '2'], :selected => '1'%>
+        <% else %>
+          <div id="user_access_public_privat" class="private"> </div>
+          <%= f.select :access_level_id, ['1', '2'], :selected => '2'%>
+        <% end %>
       <% end %>
     </div>
   <% end %>

--- a/app/views/users/_form.html.erb
+++ b/app/views/users/_form.html.erb
@@ -94,6 +94,13 @@
 </div>
 
 <div class="control-group">
+  <label for="user_comment_private_by_default"><%= t("users.private") %></label>
+  <div class="controls">
+    <%= check_box(:user, :comment_private_by_default)%>
+  </div>
+</div>
+
+<div class="control-group">
   <label for="user_time_format"><%= t("users.time_format") %></label>
   <div class="controls">
     <%= select 'user', 'time_format', [ ['16:00', '%H:%M'], ['4:00 PM', '%I:%M%p'] ] %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -855,6 +855,7 @@ en:
     date_format: Date Format
     track_time: Track Time
     show_avatars: Show Avatars
+    private: Comment Private By Default
     general: General
     access_control: Access Control
     email_addresses: Email Addresses

--- a/db/migrate/20150805105901_add_comment_private_to_users.rb
+++ b/db/migrate/20150805105901_add_comment_private_to_users.rb
@@ -1,0 +1,5 @@
+class AddCommentPrivateToUsers < ActiveRecord::Migration
+  def change
+      add_column :users, :comment_private_by_default, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended to check this file into your version control system.
 
-ActiveRecord::Schema.define(:version => 20130612150509) do
+ActiveRecord::Schema.define(:version => 20150805105901) do
 
   create_table "access_levels", :force => true do |t|
     t.string   "name"
@@ -721,6 +721,7 @@ ActiveRecord::Schema.define(:version => 20130612150509) do
     t.datetime "reset_password_sent_at"
     t.boolean  "need_schedule"
     t.boolean  "receive_notifications",                     :default => true
+    t.boolean  "comment_private_by_default",                :default => false
   end
 
   add_index "users", ["autologin"], :name => "index_users_on_autologin"


### PR DESCRIPTION
When a user enables "comment private by default" in "Account" settings, their comments will be posted "private" by default, same applies for comments through emails .