### PR TITLE
 while creating new task only list projects for which user has permission to edit or create

### DIFF
--- a/app/helpers/tasks_helper.rb
+++ b/app/helpers/tasks_helper.rb
@@ -100,9 +100,8 @@ module TasksHelper
   end
 
   # Returns a list of options to use for the project select tag.
-  def options_for_user_projects(task)
-    projects = current_user.projects.includes(:customer).except(:order).order("customers.name, projects.name")
-
+  def options_for_user_projects(task, current_user = nil)
+    projects = current_user.projects.includes(:customer).except(:order).order("customers.name, projects.name").joins(:project_permissions).where("project_permissions.can_create= ? or project_permissions.can_edit=?",true,true)
     unless task.new_record? or task.project.nil? or projects.include?(task.project)
       projects << task.project
       projects = projects.sort_by { |project| project.customer.name + project.name }

--- a/app/views/tasks/_details.html.erb
+++ b/app/views/tasks/_details.html.erb
@@ -14,7 +14,7 @@
   <div class="control-group">
     <label for="task_project_id"><%= t("tasks.project") %></label>
     <select name="task[project_id]" id="task_project_id" <%= "disabled=\"disabled\"" unless perms['reassign'].empty? %>>
-      <%= options_for_user_projects(@task) %>
+      <%= options_for_user_projects(@task, current_user) %>
     </select>
   </div>
 

--- a/test/unit/helpers/tasks_helper_test.rb
+++ b/test/unit/helpers/tasks_helper_test.rb
@@ -15,7 +15,7 @@ include ApplicationHelper
     perm.set('create')
     perm.save!
     perm_temp = ProjectPermission.new(:project => @project_temp, :user => @user)
-perm_temp.remove('all')
+    perm_temp.remove('all')
     perm_temp.set('comment')
     perm_temp.set('see_unwatched')
     perm_temp.save!

--- a/test/unit/helpers/tasks_helper_test.rb
+++ b/test/unit/helpers/tasks_helper_test.rb
@@ -1,0 +1,30 @@
+require "test_helper"
+
+class TasksHelperTest < ActionView::TestCase
+include ApplicationHelper
+  setup do
+    @user = User.make
+    @project = Project.make(:company => @user.company)
+    @project_temp = Project.make(:company => @user.company)
+    #create two projects for the same user, one with create permission
+    perm = ProjectPermission.new(:project => @project, :user => @user)
+    perm.remove('all')
+    perm.set('comment')
+    perm.set('see_unwatched')
+    #create permission
+    perm.set('create')
+    perm.save!
+    perm_temp = ProjectPermission.new(:project => @project_temp, :user => @user)
+perm_temp.remove('all')
+    perm_temp.set('comment')
+    perm_temp.set('see_unwatched')
+    perm_temp.save!
+  end
+
+  should "Project drop down lists only projects user have create or edit permission for" do     
+    @task =  TaskRecord.new(:company => @project.company)
+    @options = options_for_user_projects(@task, @user)
+    assert @options.to_s.match(@project.id.to_s).present?
+    assert !(@options.to_s.match(@project_temp.id.to_s).present?)
+  end
+end


### PR DESCRIPTION
While we are creating a new task, "project drop down" list is restricted to "projects" for which user has edit or create permission.

https://squish.ish.com.au/tasks/25670