### PR TITLE
Remove duplication of users while switching projects incase of same default users

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -277,12 +277,16 @@ function addCustomerToProject(event, ui){
 
 function addDefaultUser(event,ui) {
   var userId = ui.item.id;
-    var params = { user_id : userId};
-    addUser('/projects/add_default_user', params);
+  var users = jQuery('.username span').map(function(){
+    return jQuery(this).text();
+  }).get().join();
+  var params = { user_id : userId, users: users};
+  addUser('/projects/add_default_user', params);
 
-    jQuery("#default_user_name_auto_complete").val("");
-    return false;
-  }
+  jQuery("#default_user_name_auto_complete").val("");
+  return false;
+}
+
 function addCustomerToUser(event, ui){
   jQuery('#user_customer_id').val(ui.item.id);
   jQuery('#user_customer_link').attr("href", "/customers/edit/" + ui.item.id);

--- a/app/assets/javascripts/tasks/task_details_editor.js
+++ b/app/assets/javascripts/tasks/task_details_editor.js
@@ -54,13 +54,16 @@ jobsworth.tasks.TaskDetailsEditor = (function($) {
   }
 
   TaskDetailsEditor.prototype.addDefaultUsers = function(pid) {
-     var self = this;
-     var projectId = pid;
-     var params = {project_id : projectId, id: this.options.taskId};
-     jQuery.get('/tasks/get_default_watchers_for_project', params, function(data) {
-     jQuery("#task_users  div.user_list").append(data);
-     $(self.el).trigger("users:changed");
-      }, 'html');
+    var self = this;
+    var projectId = pid;
+    var users = $('.username span').map(function(){
+      return $(this).text();
+    }).get().join();
+    var params = {project_id : projectId, id: this.options.taskId, users: users};
+    jQuery.get('/tasks/get_default_watchers_for_project', params, function(data) {
+      jQuery("#task_users  div.user_list").not(":has(a)").append(data);
+      $(self.el).trigger("users:changed");
+    }, 'html');
     return false;
   }
 

--- a/app/controllers/projects_controller.rb
+++ b/app/controllers/projects_controller.rb
@@ -20,7 +20,15 @@ class ProjectsController < ApplicationController
   end
 
   def add_default_user
-    user = current_user.company.users.active.find(params[:user_id])
+    if params[:user_id]
+      user = current_user.company.users.active.find(params[:user_id])
+    end
+    if params[:users]
+      @existing_users = User.where("name in (?)", params[:users])
+      if @existing_users.include?(user)
+        user = []
+      end
+    end
     render(:partial => "projects/add_default_user", :locals => { :user => user})
   end
 

--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -305,11 +305,12 @@ class TasksController < ApplicationController
     if !params[:id].blank?
       @task = AbstractTask.accessed_by(current_user).find_by_id(params[:id])
     end
+    @existing_users = User.where("name in (?)", params[:users])
     users = []
     if params[:project_id].present?
       users = Project.find(params[:project_id]).default_users
     end
-    users.reject! {|u| @task.users.include?(u) }
+    users.reject! {|u| @task.users.include?(u) && @existing_users.include?(u) }
     res = render_to_string(:partial => "tasks/notification",:collection => users)
     render :text => res
   end

--- a/app/views/projects/_add_default_user.html.erb
+++ b/app/views/projects/_add_default_user.html.erb
@@ -1,7 +1,8 @@
-
-<div id="default">
-  <% active_class = user.active ? "":"inactive" %>
-  <%= link_to user.to_html, [:edit, user], :class => "username pull-left #{active_class}", :target => "_blank" %>
-  <%= hidden_field_tag("project[default_user_ids][]", user.id) %>
-  <%= link_to('<i class="icon-remove"></i>'.html_safe, "#", :class => "removeLink") %>
-</div>
+<% if user.present? %>
+  <div id="default">
+    <% active_class = user.active ? "":"inactive" %>
+    <%= link_to user.to_html, [:edit, user], :class => "username pull-left #{active_class}", :target => "_blank" %>
+    <%= hidden_field_tag("project[default_user_ids][]", user.id) %>
+    <%= link_to('<i class="icon-remove"></i>'.html_safe, "#", :class => "removeLink") %>
+  </div>
+<% end %>


### PR DESCRIPTION
While creating a task, if we have same "default users" for some projects and when you switch between those projects , duplication of users in  "users to notify" list is fixed.