### PR TITLE
Fix snippets reordering in index page

### DIFF
--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -57,6 +57,7 @@ class SnippetsController < ApplicationController
       t.position=snippet[:position]
       t.save!
     end
+    current_user.company.touch
     render :nothing=>true
   end
 

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -5,7 +5,7 @@ class SnippetsController < ApplicationController
   layout "admin"
 
   def index
-    @snippets = current_user.company.snippets
+    @snippets = current_user.company.snippets.order("position")
 
     respond_to do |format|
       format.html # index.html.erb

--- a/app/controllers/snippets_controller.rb
+++ b/app/controllers/snippets_controller.rb
@@ -57,6 +57,7 @@ class SnippetsController < ApplicationController
       t.position=snippet[:position]
       t.save!
     end
+    # touch company so that task_form cache is invalidated
     current_user.company.touch
     render :nothing=>true
   end

--- a/app/views/tasks/_form.html.erb
+++ b/app/views/tasks/_form.html.erb
@@ -23,7 +23,7 @@
     <%= render(:partial => "new_comment", locals: { show_timer: show_timer } ) %>
   </div>
 <% else %>
-  <% cache([ "task_form", @task, current_user.id, controller.controller_name, @task.try(:updated_at), @task.project.try(:updated_at), @task.milestone.try(:updated_at), show_timer  ]) do -%>
+  <% cache([ "task_form", @task, current_user.id, controller.controller_name, @task.try(:updated_at), @task.project.try(:updated_at), current_user.company.try(:updated_at), @task.milestone.try(:updated_at), show_timer  ]) do -%>
     <div id="task_addcomment">
       <%= text_area "task", "description", { :rows => 8, :cols=> nil, :class => "autogrow", :placeholder => t("tasks.enter_task_desc") }.merge( perms['edit'] ) %>
 


### PR DESCRIPTION
After the reordering of snippets through drag and drop, snippets list in the 'index' is now ordered as per position.