### PR TITLE
Improve forecast date UI

### DIFF
--- a/app/assets/stylesheets/task.scss
+++ b/app/assets/stylesheets/task.scss
@@ -76,6 +76,11 @@
     display: inline;
     background-color: #999;
   }
+  
+  &:hover .label-target {
+    display: none;
+  }
+
 
 }
 

--- a/app/assets/stylesheets/task.scss
+++ b/app/assets/stylesheets/task.scss
@@ -8,6 +8,16 @@
   font-size: 11px;
 }
 
+.forecast {
+  font-size: 0.8em;
+}
+.target_ahead {
+  color: #ff0000;
+}
+.forecast_ahead{
+  color: green;
+}
+
 #taskform .watcher {
   padding-bottom: 3px;
   padding-top: 2px;
@@ -454,7 +464,7 @@ label .unread_icon {
       color: red;
     }
   }
-  
+
   div#target_date {
     float: left;
     margin-right: 0.5em;
@@ -604,7 +614,7 @@ fieldset#todo {
     width: 100%;
     margin-top: 0;
   }
-  
+
   img {
     float: none;
     vertical-align: middle;
@@ -772,7 +782,7 @@ div#snooze_until {
 }
 
 .cogwheel-menu >li {
-  padding-left: 25px; 
+  padding-left: 25px;
 }
 
 .cogwheel-menu >li:hover {
@@ -797,7 +807,7 @@ div#snooze_until {
 }
 
 .column-visibility {
-  left: -115% !important;  
+  left: -115% !important;
 }
 
 .groupByOptions {

--- a/app/models/time_parser.rb
+++ b/app/models/time_parser.rb
@@ -3,30 +3,46 @@ class TimeParser
 
   # Format minutes => <tt>3h 3m</tt>
   def self.format_duration(minutes, spent = false)
-    hours, minutes = minutes / 60, minutes % 60
+    weeks, days, hours, minutes = minutes / 10080 ,(minutes / 1440) % 7 , (minutes / 60) % 24, minutes % 60
 
     t_key = if spent
-      if hours.zero?
-        "shared.duration_in_minutes_spent"
-      elsif minutes.zero?
+      if !weeks.zero? &&  !days.zero?
+        "shared.duration_in_weeks_and_days_spent"
+      elsif !weeks.zero?
+        "shared.duration_in_weeks_spent"
+      elsif !days.zero? && !hours.zero?
+        "shared.duration_in_days_and_hours_spent"
+      elsif !days.zero?
+        "shared.duration_in_days_spent"
+      elsif !hours.zero? && !minutes.zero?
+        "shared.duration_in_hours_and_minutes_spent"
+      elsif !hours.zero?
         "shared.duration_in_hours_spent"
       else
-        "shared.duration_in_hours_and_minutes_spent"
+        "shared.duration_in_minutes_spent"
       end
     else
-      if hours.zero?
-        "shared.duration_in_minutes"
-      elsif minutes.zero?
+      if !weeks.zero? &&  !days.zero?
+        "shared.duration_in_weeks_and_days"
+      elsif !weeks.zero?
+        "shared.duration_in_weeks"
+      elsif !days.zero? && !hours.zero?
+        "shared.duration_in_days_and_hours"
+      elsif !days.zero?
+        "shared.duration_in_days"
+      elsif !hours.zero? && !minutes.zero?
+        "shared.duration_in_hours_and_minutes"
+      elsif !hours.zero?
         "shared.duration_in_hours"
       else
-        "shared.duration_in_hours_and_minutes"
+        "shared.duration_in_minutes"
       end
     end
-    I18n.t(t_key, :hours => hours, :minutes => minutes)
+    I18n.t(t_key, :weeks => weeks.abs, :days => days.abs, :hours => hours.abs, :minutes => minutes.abs)
   end
 
   ###
-  # Parses the date string according to the 
+  # Parses the date string according to the
   # current user's prefs. If no date is found, the current
   # date is returned.
   # The returned data will always be in UTC.
@@ -64,5 +80,5 @@ class TimeParser
 
     total
   end
-  
+
 end

--- a/app/views/tasks/_details.html.erb
+++ b/app/views/tasks/_details.html.erb
@@ -32,26 +32,23 @@
   </div>
 
   <div class="control-group clearfix">
-    <label for="task[due_at]"> <%= t("tasks.target_date") %> </label>
+    <% task_due_at = @task.due_at || @task.milestone.try(:due_at) %>
+    <label for="task[due_at]"> <%= t("tasks.target_date") %>
+    <% unless @task.resolved? or @task.new_record? %>
+      <% if task_due_at and @task.estimate_date %>
+        <% forecast_duration_minutes = (@task.estimate_date.to_date - task_due_at.to_date).to_i * 24 * 60 %>
+        <% if task_due_at.beginning_of_day < @task.estimate_date.beginning_of_day %>
+          <span class="forecast target_ahead">forecast -<%= TimeParser.format_duration(forecast_duration_minutes) %></span>
+        <% else %>
+          <span class="forecast forecast_ahead">forecast <%= TimeParser.format_duration(forecast_duration_minutes) %></span>
+        <% end %>
+      <% end %>
+    <% end %>
+    </label>
     <div id="due_date_field" class="pull-left">
       <%= due_date_field(@task, perms) %>
-    </div>
-    <% task_due_at = @task.due_at || @task.milestone.try(:due_at) %>
-    <% if task_due_at and @task.estimate_date and task_due_at.beginning_of_day < @task.estimate_date.beginning_of_day %>
-      <label></label>
-      <div class="error pull-left">
-        <i class="icon-warning-sign"></i>
-        <%= t("tasks.forecast_to_miss") %>
-      </div>
-    <% end %>
+    </div>  
   </div>
-
-  <% unless @task.resolved? or @task.new_record? %>
-    <div class="control-group">
-      <label><%= t("tasks.forecast_date") %></label>
-      <span style="margin-top:0.6em;float:left;"><%= @task.estimate_date ? @task.estimate_date.strftime(current_user.date_format) : "unknown"  %></span>
-    </div>
-  <% end %>
 
   <div class="control-group">
     <label for="task_status"><%= t("tasks.resolution") %></label>

--- a/app/views/tasks/_notification.html.erb
+++ b/app/views/tasks/_notification.html.erb
@@ -25,10 +25,10 @@
 
   <% active_class = user.active ? "":"inactive" %>
   <%= link_to user.to_html, "/users/edit/#{user.id}", :class => "username pull-left #{active_class}", :target => "_blank" %>&nbsp;
-  <span class="label">
-    <% if @task.estimate_date.present? %>
+  <% if @task.estimate_date.present? %>
+    <span class="label-target label">
       <%= @task.estimate_date.strftime("%a") %>
-    <% end %>
-  </span>
+    </span>
+  <% end %>
   <%= link_to('<i class="icon-remove"></i>'.html_safe, "#", :class => "removeLink") %>
 </div>

--- a/app/views/tasks/_notification.html.erb
+++ b/app/views/tasks/_notification.html.erb
@@ -26,7 +26,9 @@
   <% active_class = user.active ? "":"inactive" %>
   <%= link_to user.to_html, "/users/edit/#{user.id}", :class => "username pull-left #{active_class}", :target => "_blank" %>&nbsp;
   <span class="label">
-    <%= @task.estimate_date.strftime("%a") %>
+    <% if @task.estimate_date.present? %>
+      <%= @task.estimate_date.strftime("%a") %>
+    <% end %>
   </span>
   <%= link_to('<i class="icon-remove"></i>'.html_safe, "#", :class => "removeLink") %>
 </div>

--- a/app/views/tasks/_notification.html.erb
+++ b/app/views/tasks/_notification.html.erb
@@ -24,6 +24,9 @@
   </label>
 
   <% active_class = user.active ? "":"inactive" %>
-  <%= link_to user.to_html, "/users/edit/#{user.id}", :class => "username pull-left #{active_class}", :target => "_blank" %>
+  <%= link_to user.to_html, "/users/edit/#{user.id}", :class => "username pull-left #{active_class}", :target => "_blank" %>&nbsp;
+  <span class="label">
+    <%= @task.estimate_date.strftime("%a") %>
+  </span>
   <%= link_to('<i class="icon-remove"></i>'.html_safe, "#", :class => "removeLink") %>
 </div>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -213,7 +213,7 @@ en:
     today: "Today"
     tomorrow: "Tomorrow"
     yesterday: "Yesterday"
-    today_or_earlier: "Today or earlier"   
+    today_or_earlier: "Today or earlier"
     today_or_later: "Today or later"
     tomorrow_or_earlier: "Tomorrow or earlier"
     tomorrow_or_later: "Tomorrow or later"
@@ -1176,9 +1176,17 @@ en:
     x_days_ago: '%{x} days ago'
     duration_in_hours: '%{hours}h'
     duration_in_minutes: '%{minutes}m'
+    duration_in_days: '%{days}d'
+    duration_in_weeks: '%{weeks}w'
+    duration_in_weeks_and_days: '%{weeks}w %{days}d'
+    duration_in_days_and_hours: '%{days}d %{hours}h'
     duration_in_hours_and_minutes: '%{hours}h %{minutes}m'
     duration_in_hours_spent: '%{hours}h spent'
     duration_in_minutes_spent: '%{minutes}m spent'
+    duration_in_days_spent: '%{days}d spent'
+    duration_in_weeks_spent: '%{weeks}w spent'
+    duration_in_weeks_and_days_spent: '%{weeks}w %{days}d spent'
+    duration_in_days_and_hours_spent: '%{days}d %{hours}h spent'
     duration_in_hours_and_minutes_spent: '%{hours}h %{minutes}m spent'
     monday_short: Mon
     tuesday_short: Tue

--- a/test/unit/time_parser_test.rb
+++ b/test/unit/time_parser_test.rb
@@ -3,12 +3,28 @@ require "test_helper"
 class TimeParserTest < ActiveSupport::TestCase
   #   def self.format_duration(minutes)
   context "format duration" do
+    should "be able to format weeks" do
+      assert_equal "2w", TimeParser.format_duration(20160)
+    end
+
+    should "be able to format days" do
+      assert_equal "2d", TimeParser.format_duration(2880)
+    end
+
     should "be able to format hours" do
       assert_equal "2h", TimeParser.format_duration(120)
     end
 
     should "be able to format minutes" do
       assert_equal "4m", TimeParser.format_duration(4)
+    end
+
+    should "be able to format weeks and days" do
+      assert_equal "2w 2d", TimeParser.format_duration(23040)
+    end
+
+    should "be able to format days and hours" do
+      assert_equal "2d 2h", TimeParser.format_duration(3000)
     end
 
     should "be able to format hours and minutes" do
@@ -42,4 +58,3 @@ end
 #  created_at :datetime
 #  updated_at :datetime
 #
-


### PR DESCRIPTION
1. Removed the forecast date field from the task edit view and added forecast text with time detail in the target date label.
2. Added new pill next to assigned user to show the task is forecast to be worked on.
https://github.com/ari/jobsworth/issues/530