### PR TITLE
Removed acts_as_tree gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,7 +10,6 @@ gem 'RedCloth', :require => 'redcloth'
 gem 'gchartrb', :require => "google_chart"
 gem 'paperclip'
 gem 'json'
-gem 'acts_as_tree', '=1.5'
 gem 'acts_as_list'
 gem 'dynamic_form'
 gem 'remotipart'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -66,8 +66,6 @@ GEM
       tzinfo (~> 1.1)
     acts_as_list (0.7.2)
       activerecord (>= 3.0)
-    acts_as_tree (1.5.0)
-      activerecord (>= 3.0.0)
     addressable (2.4.0)
     annotate (2.7.0)
       activerecord (>= 3.2, < 6.0)
@@ -371,7 +369,6 @@ DEPENDENCIES
   activerecord-jdbcsqlite3-adapter
   activerecord-session_store
   acts_as_list
-  acts_as_tree (= 1.5)
   annotate
   bootstrap-sass
   capybara


### PR DESCRIPTION
No usage of this gem found anywhere in the app. The columns required to manage the tree were removed in ChangeFoldersToActsAsTree migration.