### PR TITLE
Fix js error in tasks list

### DIFF
--- a/app/assets/javascripts/grid.js
+++ b/app/assets/javascripts/grid.js
@@ -55,7 +55,7 @@ jobsworth.Grid = (function($){
 
     $.getJSON("/companies/properties", function(data) {
       for(var index in data) {
-        var property = data[index]["property"]
+        var property = data[index]
         columns.push({
           id: property.name.toLowerCase(),
           name: property.name.toLowerCase(),


### PR DESCRIPTION
JSON wrapping rules do have changed. In Rails 3 wrapping JSON (property.as_json -> property: {id: 1, name: 2}) was by default and now it is not.