### PR TITLE
add resource scripts to routes

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -243,4 +243,6 @@ Jobsworth::Application.routes.draw do
 
   match ':controller/redirect_from_last' => :redirect_from_last, :via => [:get]
 
+  resources :scripts, only: :index
+
 end


### PR DESCRIPTION
There were no routes for scripts. Resource scripts fixes this error.