### PR TITLE
Using udp connection to avoid application blocking. Fixes #598

### DIFF
--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -3,9 +3,9 @@ Jobsworth::Application.configure do
   config.logstash.progname = 'Jobsworth'
   config.log_level = :info
   config.logstash.formatter = ::Logger::Formatter
-  #config.logstash.port = 5000
-  #config.logstash.type = :tcp
-  #config.logstash.host = '0.0.0.0'
+  config.logstash.port = 5000
+  config.logstash.type = :udp
+  config.logstash.host = '0.0.0.0'
   #config.logstash.ssl_enable = true
 
   config.eager_load = false
@@ -31,7 +31,7 @@ Jobsworth::Application.configure do
     :port           => 587,
     :domain         => 'gmail.com',
     :authentication => :login,
-    :user_name      => 'username@host.com',
+    :user_name      => 'username@host.com', #ex. intale.a@gmail.com
     :password       => 'password'
   }
 

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -31,7 +31,7 @@ Jobsworth::Application.configure do
     config.logstash.progname = 'Jobsworth'
     config.logstash.formatter = :json_lines
     config.logstash.port = config.jobsworth.logstash_port
-    config.logstash.type = :tcp
+    config.logstash.type = :udp
     config.logstash.host = config.jobsworth.logstash_host
     config.logstash.ssl_enable = true
   end


### PR DESCRIPTION
UDP connection won't break application if logstash server unavailable.