### PR TITLE
Task properties & wrong forecast date

### DIFF
--- a/app/assets/javascripts/application.js.erb
+++ b/app/assets/javascripts/application.js.erb
@@ -385,11 +385,11 @@ jQuery(document).ready(function () {
   // fix checkbox in nested form has no effect for new record
   jQuery("input.nested-checkbox").live("change", function() {
     checkbox = jQuery(this);
-    var checked = checkbox.attr("checked");
+    var checked = checkbox.prop("checked");
 
     var hiddenField = checkbox.prev();
-    if (hiddenField.attr("name") == checkbox.attr("name")) {
-      hiddenField.attr("disabled", checked);
+    if (hiddenField.prop("name") == checkbox.prop("name")) {
+      hiddenField.prop("disabled", checked);
     }
   })
 

--- a/app/assets/javascripts/task_property_edit.js
+++ b/app/assets/javascripts/task_property_edit.js
@@ -28,8 +28,8 @@ jobsworth.TaskPropertyEdit = (function($){
     })
 
     $("input.default").live('change', function(){
-      $('.default').attr('checked', false);
-      $(this).attr('checked', true);
+      $('.default').prop('checked', false);
+      $(this).prop('checked', true);
     })
 
     $("input.preset-checkbox").live("change", function() {
@@ -89,12 +89,9 @@ jobsworth.TaskPropertyEdit = (function($){
 
   TaskPropertyEdit.prototype.reorderPropertyValue = function(event, ui) {
     var pvs = [];
-    $.each(
-      $('li.property_value'),
-      function(index, element){
-        pvs.push($(element).attr("id").replace("property_value_", ""));
-      }
-    );
+      $('.property_value.clearfix').each(function(index, element){
+        pvs.push($(element).prop("id").replace("property_value_", ""));
+      });
     $.post('/properties/order', { property_values: pvs } );
   }
 

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -53,7 +53,7 @@ class PropertiesController < ApplicationController
   # PUT /properties/1.xml
   def update
     update_existing_property_values(@property)
-    @property.property_values.build(new_property_values_attributes) if new_property_values_attributes.present?
+    @property.property_values.build(new_property_values_attributes) if new_property_values_attributes[0]['value'].present?
 
     saved = @property.update_attributes(property_attributes)
     # force company in case somebody passes in company_id param
@@ -84,8 +84,8 @@ class PropertiesController < ApplicationController
   end
 
   def order
-    if property_values_attributes
-      values = property_values_attributes.map { |id| PropertyValue.find(id) }
+    if property_values_ids
+      values = property_values_ids.reject(&:empty?).map { |id| PropertyValue.find(id) }
       # if it's a new record, we can just ignore this (because update will use the correct order)
       if values.first.property
         values.each_with_index do |v, i|
@@ -169,6 +169,10 @@ class PropertiesController < ApplicationController
 
     def property_values_attributes
       params.fetch(:property_values, {}).permit!
+    end
+
+    def property_values_ids
+      params.fetch(:property_values, {})
     end
 
 end

--- a/app/controllers/properties_controller.rb
+++ b/app/controllers/properties_controller.rb
@@ -53,7 +53,8 @@ class PropertiesController < ApplicationController
   # PUT /properties/1.xml
   def update
     update_existing_property_values(@property)
-    @property.property_values.build(new_property_values_attributes) if new_property_values_attributes[0]['value'].present?
+    not_empty_property_value = new_property_values_attributes[0]['value'] if new_property_values_attributes.present?
+    @property.property_values.build(new_property_values_attributes) if not_empty_property_value.present?
 
     saved = @property.update_attributes(property_attributes)
     # force company in case somebody passes in company_id param

--- a/app/views/properties/_property_value.html.erb
+++ b/app/views/properties/_property_value.html.erb
@@ -13,7 +13,7 @@
           <div class="controls">
             <%= f.text_field :value, :index => pv.id %>
             <%= sortable_handle_tag(pv) %>
-            <%= link_to "Remove value", "#", :class => "remove_property_value_link" %>
+            <%= link_to "Remove value", "#", :class => "remove_property_value_link" unless pv.new_record?%>
           </div>
         </div>
 

--- a/app/views/tasks/_notification.html.erb
+++ b/app/views/tasks/_notification.html.erb
@@ -25,7 +25,7 @@
 
   <% active_class = user.active ? "":"inactive" %>
   <%= link_to user.to_html, edit_user_path(user), :class => "username pull-left #{active_class}", :target => "_blank" %>&nbsp;
-  <% if @task.estimate_date.present? && !@task.snoozed? %>
+  <% if @task.estimate_date.present? && !@task.snoozed? && @task.owners.include?(user) %>
     <span class="label label-warning">
       <%= human_future_date(@task.estimate_date, user.tz) %>
     </span>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -152,6 +152,7 @@ Jobsworth::Application.routes.draw do
     collection do
       get :remove_property_value_dialog
       post :remove_property_value
+      post :order
     end
   end
 


### PR DESCRIPTION
Don't show wrong forecast date for new assigned users before save task.
Fix problems from list above (https://github.com/ari/jobsworth/issues/617)
1. Cannot tick the 'default' checkbox.
2. Clicking save without adding a new property causes a new blank property to be added
3. "Remove value" in new property section make no sense
4. Drag and drop to rearrange ordering doesn't work